### PR TITLE
Add Size Limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.rollup.js
 !.tape.js
 !.travis.yml
+!.size-limit.json
 *.log*
 *.result.css
 /browser.*

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,6 @@
+[
+  {
+    "path": "index.js",
+    "limit": "285 B"
+  }
+]

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,7 @@
 [
   {
     "path": "index.js",
-    "limit": "285 B"
+    "limit": "285 B",
+    "running": false
   }
 ]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [dsc] is a JavaScript function for defining DOM structures. It takes an
 element, properties or attributes, children, and returns a DOM structure. It
-will add up to 358 bytes to your project.
+will add up to 285 bytes to your project.
 
 ```
 dsc(element, attributes, ...children)

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "build": "npm run build:browser && npm run build:node",
     "build:browser": "NODE_ENV=browser rollup --config --silent",
     "build:node": "NODE_ENV=node rollup --config --silent",
-    "postbuild:browser": "g1=$(gzip-size --level 0 browser.js); g2=$(gzip-size --level 9 browser.js); echo Bundle size: $g1 / $g2 gzip",
     "prepublishOnly": "npm test && npm run build",
     "pretest:tape": "npm run build:node",
-    "test": "npm run test:js && npm run test:tape",
+    "test": "npm run test:js && npm run test:tape && npm run test:size",
     "test:js": "eslint src/*.js --cache --ignore-path .gitignore --quiet",
-    "test:tape": "node test"
+    "test:tape": "node test",
+    "test:size": "size-limit"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -43,7 +43,8 @@
     "pre-commit": "^1.2.2",
     "rollup": "^1.10.1",
     "rollup-plugin-babel": "^4.3.2",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-terser": "^4.0.4",
+    "size-limit": "^1.3.1"
   },
   "keywords": [
     "javascript",


### PR DESCRIPTION
Let’s me introduce you [Size Limit](https://github.com/ai/size-limit/) a special tool for a project taking care of performance.

Benefits compare to `gzip-size`:

* It will guard the small size of your project. If somebody will send PR bloated your library, Size Limit will throw an error on Travis CI.
* It calculates real cost by creating an empty webpack project, adding your lib as a dependency and checking the difference. This test will be much closer to real case compare to just checking the size. *In the case of your project it shows better number.* (I can explain why if you curious)
* It converts bytes to something more relevant to real life: downloading (on slow 3G) and execution time (on cheap Chinese phone).
* More accurate. It tracks dependency and webpack polyfills (for instance, mentioning `process` in lib will force webpack to insert few KB polyfill for it). *It is not important for this library but it is nice to have it.*
* It supports library with multiple files. In this case, it even shows what file or dependency was a reason for big size. *It is not important for this library but it is nice to have it.*

Possible side effects:

* Size Limit has more dependencies
* It works slower. But if it bothers you, you can add `webpack: false, running: false` and have the same `gzip-size` performance.
* It adds one extra config.